### PR TITLE
Added check and fix for global --install.ignore-scripts yarn config

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,5 +19,5 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
 
-      - run: yarn
+      - run: yarn --ignore-scripts
       - run: yarn test

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,8 @@ ENV NODE_ENV=$NODE_ENV
 
 # Install dependencies based on the environment
 RUN if [ "$NODE_ENV" = "development" ]; \
-    then yarn install; \
-    else yarn install --production; \
+    then yarn install --ignore-scripts; \
+    else yarn install --ignore-scripts --production; \
     fi
 
 # Copy the rest of the application files

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - /usr/src/app/node_modules # Prevent overwriting node_modules
     environment:
       - NODE_ENV=development
-    command: ["sh", "-c", "yarn install && yarn dev"] # Correct list format
+    command: ["sh", "-c", "yarn install --ignore-scripts && yarn dev"] # Correct list format
     depends_on:
       - clickhouse
 


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PRO-1540/

- there have been multiple recent npm incidents with compromised packages using pre/post-install scripts to run malicious scripts
- we want to default to not running these scripts as a security precaution this matches behaviour of pnpm which is touted as a modern, more secure, npm package manager